### PR TITLE
傾斜配点を追加

### DIFF
--- a/api/line.js
+++ b/api/line.js
@@ -32,14 +32,14 @@ async function handleEvent(event) {
       }
       break
     case message.actionDef.SETCLASSNUM:
-      const reply = await action.setClassNum(event)
-      if (reply) {
+      const reply3 = await action.setClassNum(event)
+      if (reply3) {
         return client.replyMessage(event.replyToken, reply)
       }
       break
     case message.actionDef.COUNT:
-      const reply3 = await action.coutFromMessage(event, client)
-      if (reply3) {
+      const reply4 = await action.coutFromMessage(event, client)
+      if (reply4) {
         return client.replyMessage(event.replyToken, reply3)
       }
       break

--- a/api/line.js
+++ b/api/line.js
@@ -31,6 +31,12 @@ async function handleEvent(event) {
         return client.replyMessage(event.replyToken, reply2)
       }
       break
+    case message.actionDef.SETCLASSNUM:
+      const reply = await action.setClassNum(event)
+      if (reply) {
+        return client.replyMessage(event.replyToken, reply)
+      }
+      break
     case message.actionDef.COUNT:
       const reply3 = await action.coutFromMessage(event, client)
       if (reply3) {

--- a/api/line.js
+++ b/api/line.js
@@ -34,13 +34,13 @@ async function handleEvent(event) {
     case message.actionDef.SETCLASSNUM:
       const reply3 = await action.setClassNum(event)
       if (reply3) {
-        return client.replyMessage(event.replyToken, reply)
+        return client.replyMessage(event.replyToken, reply3)
       }
       break
     case message.actionDef.COUNT:
       const reply4 = await action.coutFromMessage(event, client)
       if (reply4) {
-        return client.replyMessage(event.replyToken, reply3)
+        return client.replyMessage(event.replyToken, reply4)
       }
       break
     default:

--- a/modules/action.js
+++ b/modules/action.js
@@ -127,8 +127,22 @@ async function setName(event) {
   }]
 }
 
+async function setClassNum(event) {
+  const newNumber = message.detectClassNum(event.message.text)
+  if (newNumber === null) {
+    return null
+  }
+  if (await db.setClassNum(event.source.userId, newNumber) === 1) {
+    return errorRep
+  }
+  return [{
+    type: 'text', text: `科目数を${newNumber.toString()}に変更したよ。`
+  }]
+}
+
 module.exports = {
   coutFromMessage: countFromMessage,
   setName: setName,
+  setClassNum: setClassNum,
   ranking: ranking
 }

--- a/modules/action.js
+++ b/modules/action.js
@@ -83,7 +83,7 @@ async function ranking() {
         absent: Number(item.data.M.absent.N),
         late: Number(item.data.M.late.N),
         displayName: item.data.M.displayName.S,
-        classNum: Number(item.data.M.classNumber.N)
+        classNum: item.data.M.classNumber ? Number(item.data.M.classNumber.N) : 1
       }
     }
   ))

--- a/modules/action.js
+++ b/modules/action.js
@@ -94,7 +94,7 @@ async function ranking() {
     }
     return b.absent - a.absent
   }
-  const sorted = data.sort(customSort)
+  const sorted = data.sort((a, b) => customSort(a.data, b.data))
   const textArr = sorted.map((item, index) => {
     // rank starts with 0
     // undefinedへのアクセスを避けるため

--- a/modules/action.js
+++ b/modules/action.js
@@ -71,7 +71,7 @@ function makeGraphText(label, count) {
 }
 
 function calcPoint(absent, late, classNum) {
-  return (absent * 2 + late) * 25 / classNum
+  return Math.round((absent * 2 + late) * 25 / classNum)
 }
 
 async function ranking() {

--- a/modules/db.js
+++ b/modules/db.js
@@ -125,9 +125,9 @@ async function setClassNum(userId, num) {
       '#N': 'classNumber'
     },
     ExpressionAttributeValues: {
-      ':number': {S: String(num)}
+      ':number': {N: String(num)}
     },
-    UpdateExpression: 'SET #D.#N = :name',
+    UpdateExpression: 'SET #D.#N = :number',
     ReturnValues: 'UPDATED_NEW'
   }
   try {

--- a/modules/db.js
+++ b/modules/db.js
@@ -112,6 +112,33 @@ async function setName(userId, name) {
   }
 }
 
+async function setClassNum(userId, num) {
+  const params = {
+    TableName: tableName,
+    Key: {
+      '_id': {
+        S: userId
+      }
+    },
+    ExpressionAttributeNames: {
+      '#D': 'data',
+      '#N': 'classNumber'
+    },
+    ExpressionAttributeValues: {
+      ':number': {S: String(num)}
+    },
+    UpdateExpression: 'SET #D.#N = :name',
+    ReturnValues: 'UPDATED_NEW'
+  }
+  try {
+    const res = await dynamo.updateItem(params).promise()
+    return res
+  } catch(err) {
+    console.error(err)
+    return 1
+  }
+}
+
 async function scan() {
   const params = {
     TableName: tableName
@@ -130,5 +157,6 @@ module.exports = {
   create: createData,
   update: updateData,
   setName: setName,
+  setClassNum: setClassNum,
   scan: scan
 }

--- a/modules/handleMessage.js
+++ b/modules/handleMessage.js
@@ -1,7 +1,8 @@
 const actionDef = {
   COUNT: 'COUNT',
   RANKING: 'RANKING',
-  SETNAME: 'SETNAME'
+  SETNAME: 'SETNAME',
+  SETCLASSNUM: 'SETCLASSNUM'
 }
 
 function trigger(message) {
@@ -14,6 +15,9 @@ function trigger(message) {
   }
   if (trimmed.startsWith('名前変更')) {
     return actionDef.SETNAME
+  }
+  if (trimmed.startsWith('科目数')) {
+    return actionDef.SETCLASSNUM
   }
   const words = ['遅刻', '欠席']
   for (const word of words) {
@@ -106,9 +110,20 @@ function detectDisplayName(text) {
   return null
 }
 
+function detectClassNum(text) {
+  if (text.startsWith('科目数')) {
+    const num = Number(text.slice(3).trim())
+    if (Number.isInteger(num) && num > 0 && num <= 25) {
+      return num
+    }
+  }
+  return null
+}
+
 module.exports = {
   actionDef: actionDef,
   trigger: trigger,
   count: countAbsentLate,
-  detectName: detectDisplayName
+  detectName: detectDisplayName,
+  detectClassNum: detectClassNum
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,9 +37,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "12.7.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.8.tgz#cb1bf6800238898bc2ff6ffa5702c3cadd350708"
-  integrity sha512-FMdVn84tJJdV+xe+53sYiZS4R5yn1mAIxfj+DVoNiQjTYz1+OYmjwEZr1ev9nU0axXwda0QDbYl06QHanRVH3A==
+  version "12.7.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
+  integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
 
 "@types/node@^7.0.31":
   version "7.10.7"
@@ -74,9 +74,9 @@ asynckit@^0.4.0:
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 aws-sdk@^2.441.0:
-  version "2.538.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.538.0.tgz#c2a6b482c191615457993d9cfb28a79d0847bb71"
-  integrity sha512-mQTo1eWoU8UB2Pp1PyBBSrFKfaFIVNKeLjJslrhHV5eW/orv2Lw07shnbY4cSt+n2oumw45WStWORyLekRvjyA==
+  version "2.544.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.544.0.tgz#d99eeada8237ee67699ce6644f8070eeb84996e7"
+  integrity sha512-wwiBJgAUGKXY/xoCSrUXVZnNtefoH3YcPwGxQrQXOIDnLMQ32yh/SWc52qmwdxA7WJzpTcIj8y+5keH3P1LYaw==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -333,9 +333,9 @@ inherits@2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 is-buffer@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
-  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-typedarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
ポイント計算に傾斜配点を追加します。
履修コマ数が多いほど配点が低くなります。

## 計算方法

```
( 欠席数 * 50 + 遅刻数 * 25 ) / 履修コマ数
```
で算出される数の小数点以下を切り捨てたものをポイントとします。
ポイントが同率の場合は、欠席数が多い人を上位とします。
欠席数も同じ場合は、同率順位とします。

**注**：履修コマ数の登録がない場合は、1科目として計算されます。早めに設定してください。

## 履修コマ数の設定方法

botに `コマ数 [number]` と話しかけます。 `[number]` は1から25までの整数です。

## 例

- 履修コマが 25 の場合
  - 欠席 1, 遅刻 2 で **4pt** となります。
- 履修コマが 10 の場合
  - 欠席 1, 遅刻 2 で **10pt** となります。
